### PR TITLE
bump minimatch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@humanwhocodes/object-schema": "^1.2.1",
     "debug": "^4.1.1",
-    "minimatch": "^3.0.4"
+    "minimatch": "^3.0.5"
   },
   "devDependencies": {
     "@nitpik/javascript": "0.4.0",


### PR DESCRIPTION
"A vulnerability was found in the minimatch package. This flaw allows a Regular Expression Denial of Service (ReDoS) when calling the braceExpand function with specific arguments, resulting in a Denial of Service."
Affected versions: < 3.0.5