### PR TITLE
fix: Ensure gitignore-style directory ignores

### DIFF
--- a/src/config-array.js
+++ b/src/config-array.js
@@ -841,7 +841,9 @@ export class ConfigArray extends Array {
 
 		assertNormalized(this);
 
-		const relativeDirectoryPath = path.relative(this.basePath, directoryPath);
+		const relativeDirectoryPath = path.relative(this.basePath, directoryPath)
+			.replace(/\\/g, '/');
+
 		if (relativeDirectoryPath.startsWith('..')) {
 			return true;
 		}
@@ -852,14 +854,35 @@ export class ConfigArray extends Array {
 		if (cache.has(relativeDirectoryPath)) {
 			return cache.get(relativeDirectoryPath);
 		}
-		
-		// first check non-/** paths
-		const result = shouldIgnorePath(
-			this.ignores, //.filter(matcher => typeof matcher === "function" || !matcher.endsWith("/**")),
-			directoryPath,
-			relativeDirectoryPath
-		);
 
+		const directoryParts = relativeDirectoryPath.split('/');
+		let relativeDirectoryToCheck = '';
+		let result = false;
+
+		/*
+		 * In order to get the correct gitignore-style ignores, where an
+		 * ignored parent directory cannot have any descendants unignored,
+		 * we need to check every directory starting at the parent all
+		 * the way down to the actual requested directory.
+		 * 
+		 * We aggressively cache all of this info to make sure we don't
+		 * have to recalculate everything for every call.
+		 */
+		do {
+
+			relativeDirectoryToCheck += directoryParts.shift() + '/';
+
+			result = shouldIgnorePath(
+				this.ignores,
+				path.join(this.basePath, relativeDirectoryToCheck),
+				relativeDirectoryToCheck
+			);
+
+			cache.set(relativeDirectoryToCheck, result);
+
+		} while (!result && directoryParts.length);
+
+		// also cache the result for the requested path
 		cache.set(relativeDirectoryPath, result);
 
 		return result;


### PR DESCRIPTION
Prior to this fix, `isDirectoryIgnored()` was incorrectly allowing the re-inclusion of previously ignored patterns even if the parent directory was already ignored.

This fix ensures that a child directory of an ignored parent cannot be unignored.