### PR TITLE
build: Use LTS Node.js version in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: lts/*
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       - run: npm ci


### PR DESCRIPTION
I believe this will fix the error that occurred in https://github.com/humanwhocodes/config-array/actions/runs/4961978783/jobs/8879447925

```
Error: Cannot find module 'node:process'
Require stack:
- /home/runner/work/config-array/config-array/node_modules/rollup/dist/bin/rollup
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:815:15)

```