### PR TITLE
fix: validate `files` and `ignores` elements

### DIFF
--- a/src/base-schema.js
+++ b/src/base-schema.js
@@ -29,7 +29,19 @@ function assertIsArrayOfStringsAndFunctions(value, name) {
 	assertIsArray(value, name);
 
 	if (value.some(item => typeof item !== 'string' && typeof item !== 'function')) {
-		throw new TypeError('Expected array to only contain strings.');
+		throw new TypeError('Expected array to only contain strings and functions.');
+	}
+}
+
+/**
+ * Assets that a given value is a non-empty array.
+ * @param {*} value The value to check.
+ * @returns {void}
+ * @throws {TypeError} When the value is not an array or an empty array.
+ */
+function assertIsNonEmptyArray(value) {
+	if (!Array.isArray(value) || value.length === 0) {
+		throw new TypeError('Expected value to be a non-empty array.');
 	}
 }
 
@@ -61,7 +73,7 @@ export const baseSchema = Object.freeze({
 		validate(value) {
 
 			// first check if it's an array
-			assertIsArray(value);
+			assertIsNonEmptyArray(value);
 
 			// then check each member
 			value.forEach(item => {

--- a/tests/config-array.test.js
+++ b/tests/config-array.test.js
@@ -332,6 +332,55 @@ describe('ConfigArray', () => {
 				.throw(/non-empty array/);
 
 		});
+
+		it('should throw an error when files contains an invalid element', async () => {
+			configs = new ConfigArray([
+				{
+					files: ['*.js', undefined]
+				}
+			], { basePath });
+			await configs.normalize();
+
+			expect(() => {
+				configs.getConfig(path.resolve(basePath, 'foo.js'));
+			})
+				.to
+				.throw('Key "files": Items must be a string, a function, or an array of strings and functions.');
+
+		});
+
+		it('should throw an error when a global ignores contains an invalid element', async () => {
+			configs = new ConfigArray([
+				{
+					ignores: ['ignored/**', -1]
+				}
+			], { basePath });
+			await configs.normalize();
+
+			expect(() => {
+				configs.getConfig(path.resolve(basePath, 'foo.js'));
+			})
+				.to
+				.throw('Key "ignores": Expected array to only contain strings and functions.');
+
+		});
+
+		it('should throw an error when a non-global ignores contains an invalid element', async () => {
+			configs = new ConfigArray([
+				{
+					files: ['*.js'],
+					ignores: [-1]
+				}
+			], { basePath });
+			await configs.normalize();
+
+			expect(() => {
+				configs.getConfig(path.resolve(basePath, 'foo.js'));
+			})
+				.to
+				.throw('Key "ignores": Expected array to only contain strings and functions.');
+
+		});
 	});
 
 	describe('ConfigArray members', () => {


### PR DESCRIPTION
This PR ensures that `files` and `ignores` properties of config objects are fully validated before they are accessed in the `getConfig` method.

This should fix issue https://github.com/eslint/eslint/issues/17434, except that we may want to add tests to the eslint repo as well.

The list of changes in the current draft implementation is as follows:
* Added a new method `assertValidFilesAndIgnores` to validate just `files` and `ignores` using the base schema logic.
* Validating `files` and `ignores` of each config (not just of the merged configs) in the `ignores` getter when no previous cache entry is found.
* Modified the base schema to also assert that the `files` array is not empty.
* Removed other assertions that are no longer necessary.
* Fixed an error message reported when `ignores` has invalid elements.