### PR TITLE
chore: fix caching of ignored files

### DIFF
--- a/src/config-array.js
+++ b/src/config-array.js
@@ -702,11 +702,11 @@ export class ConfigArray extends Array {
 		const cache = this[ConfigArraySymbol.configCache];
 
 		// first check the cache for a filename match to avoid duplicate work
-		let finalConfig = cache.get(filePath);
-
-		if (finalConfig) {
-			return finalConfig;
+		if (cache.has(filePath)) {
+			return cache.get(filePath);
 		}
+
+		let finalConfig;
 
 		// next check to see if the file should be ignored
 


### PR DESCRIPTION
Fixes `getConfig()` caching for ignored files.

Configs for ignored files are stored as `undefined` in the cache, so `if (finalConfig)` was treating them as cache misses.