### PR TITLE
fix: behavior of global `ignores`

### DIFF
--- a/src/config-array.js
+++ b/src/config-array.js
@@ -523,38 +523,7 @@ export class ConfigArray extends Array {
 			 * are additional keys, then ignores act like exclusions.
 			 */
 			if (config.ignores && Object.keys(config).length === 1) {
-
-				/*
-				 * If there are directory ignores, then we need to double up
-				 * the patterns to be ignored. For instance, `foo` will also
-				 * need `foo/**` in order to account for subdirectories.
-				 */
-				config.ignores.forEach(ignore => {
-
-					result.push(ignore);
-					
-					if (typeof ignore === 'string') {
-
-						// unignoring files won't work unless we unignore directories too
-						if (ignore.startsWith('!')) {
-
-							if (ignore.endsWith('/**')) {
-								result.push(ignore.slice(0, ignore.length - 3));
-							} else if (ignore.endsWith('/*')) {
-								result.push(ignore.slice(0, ignore.length - 2));
-							}
-						}
-
-						// directories should work with or without a trailing slash
-						if (ignore.endsWith('/')) {
-							result.push(ignore.slice(0, ignore.length - 1));
-							result.push(ignore + '**');
-						} else if (!ignore.endsWith('*')) {
-							result.push(ignore + '/**');
-						}
-
-					}
-				});
+				result.push(...config.ignores);
 			}
 		}
 

--- a/tests/config-array.test.js
+++ b/tests/config-array.test.js
@@ -1409,7 +1409,7 @@ describe('ConfigArray', () => {
 				expect(configs.isFileIgnored(path.join(basePath, 'foo/a.js'))).to.be.true;
 			});
 
-			it('should return true when file is in a directory that is ignored along its files by pattern that ends with `/**` and then unignored by pattern that does not ends with `/`', () => {
+			it('should return true when file is in a directory that is ignored along with its files by a pattern that ends with `/**` and then unignored by pattern that does not end with `/`', () => {
 				configs = new ConfigArray([
 					{
 						files: ['**/*.js']

--- a/tests/config-array.test.js
+++ b/tests/config-array.test.js
@@ -1841,7 +1841,7 @@ describe('ConfigArray', () => {
 				expect(configs.isDirectoryIgnored(path.join(basePath, 'node_modules/'))).to.be.false;
 			});
 
-			it('should return true when a directory's content is later negated with *', () => {
+			it('should return true when a directory\'s content is later negated with *', () => {
 				configs = new ConfigArray([
 					{
 						files: ['**/*.js']

--- a/tests/config-array.test.js
+++ b/tests/config-array.test.js
@@ -1367,7 +1367,7 @@ describe('ConfigArray', () => {
 				expect(configs.isFileIgnored(path.join(basePath, 'foo/a.js'))).to.be.true;
 			});
 
-			it('should return false when file is in a directory that is ignored and then unignord by pattern that end with `/`', () => {
+			it('should return false when file is in a directory that is ignored and then unignored by pattern that end with `/`', () => {
 				configs = new ConfigArray([
 					{
 						files: ['**/*.js']

--- a/tests/config-array.test.js
+++ b/tests/config-array.test.js
@@ -1387,7 +1387,7 @@ describe('ConfigArray', () => {
 				expect(configs.isFileIgnored(path.join(basePath, 'foo/a.js'))).to.be.false;
 			});
 
-			it('should return true when file is in a directory that is ignored along its files by pattern that ends with `/**` and than unignored by pattern that ends with `/`', () => {
+			it('should return true when file is in a directory that is ignored along with its files by a pattern that ends with `/**` and then unignored by pattern that ends with `/`', () => {
 				configs = new ConfigArray([
 					{
 						files: ['**/*.js']

--- a/tests/config-array.test.js
+++ b/tests/config-array.test.js
@@ -1841,7 +1841,7 @@ describe('ConfigArray', () => {
 				expect(configs.isDirectoryIgnored(path.join(basePath, 'node_modules/'))).to.be.false;
 			});
 
-			it('should return true when a directory content is later negated with *', () => {
+			it('should return true when a directory's content is later negated with *', () => {
 				configs = new ConfigArray([
 					{
 						files: ['**/*.js']


### PR DESCRIPTION
Fixes the problem in https://github.com/eslint/eslint/issues/17964#issuecomment-1879840650

In the code that calculates global ignores, there were still some transformations of patterns that, I believe, were needed in some previous versions, but are now causing unintended behavior.

For example, ignore pattern `foo/*/` should not match file `foo/a.js`.

I removed all those transformations and added several tests that demonstrate the difference in behavior after this change, and also a few regression tests.