### PR TITLE
feat: Report config name in error messages

### DIFF
--- a/src/config-array.js
+++ b/src/config-array.js
@@ -114,7 +114,6 @@ function isString(value) {
  * @param {number} index The index of the config object in the array.
  * @returns {void}
  * @throws {ConfigError} If the files and ignores keys of a config object are not valid.
- * @throws {BaseConfigError} If the files and ignores keys of a base config object are not valid.
  */
 function assertValidFilesAndIgnores(config, index) {
 

--- a/src/config-array.js
+++ b/src/config-array.js
@@ -81,7 +81,7 @@ function getConfigName(config) {
 		return `"${config.name}"`;
 	}
 
-	return '(unknown)';
+	return '(unnamed)';
 }
 
 

--- a/src/config-array.js
+++ b/src/config-array.js
@@ -41,7 +41,7 @@ class ConfigError extends Error {
 
 	/**
 	 * Creates a new instance.
-	 * @param {string|number} name The config object name or index causing the error.
+	 * @param {string} name The config object name causing the error.
 	 * @param {number} index The index of the config object in the array.
 	 * @param {Error} source The source error. 
 	 */

--- a/src/config-array.js
+++ b/src/config-array.js
@@ -91,7 +91,6 @@ function getConfigName(config) {
  * @param {number} index The index of the config object in the array.
  * @param {Error} error The error to rethrow.
  * @throws {ConfigError} When the error is rethrown for a config.
- * @throws {BaseConfigError} When the error is rethrown for a base config.
  */
 function rethrowConfigError(config, index, error) {
 	const configName = getConfigName(config, index);

--- a/src/config-array.js
+++ b/src/config-array.js
@@ -93,7 +93,7 @@ function getConfigName(config) {
  * @throws {ConfigError} When the error is rethrown for a config.
  */
 function rethrowConfigError(config, index, error) {
-	const configName = getConfigName(config, index);
+	const configName = getConfigName(config);
 	throw new ConfigError(configName, index, error);
 }
 

--- a/tests/config-array.test.js
+++ b/tests/config-array.test.js
@@ -373,7 +373,7 @@ describe('ConfigArray', () => {
 					files: ['*.js', undefined]
 				}
 			],
-			expectedError: 'Config (unknown): Key "files": Items must be a string, a function, or an array of strings and functions.'
+			expectedError: 'Config (unnamed): Key "files": Items must be a string, a function, or an array of strings and functions.'
 		});
 
 		testValidationError({
@@ -383,7 +383,7 @@ describe('ConfigArray', () => {
 					ignores: undefined
 				}
 			],
-			expectedError: 'Config (unknown): Key "ignores": Expected value to be an array.'
+			expectedError: 'Config (unnamed): Key "ignores": Expected value to be an array.'
 		});
 
 		testValidationError({
@@ -439,7 +439,7 @@ describe('ConfigArray', () => {
 				configs.getConfig(path.resolve(basePath, 'foo.js'));
 			})
 				.to
-				.throw('Config (unknown): Key "name": Property must be a string.');
+				.throw('Config (unnamed): Key "name": Property must be a string.');
 
 		});
 
@@ -457,7 +457,7 @@ describe('ConfigArray', () => {
 				configs.getConfig(path.resolve(basePath, 'foo.js'));
 			})
 				.to
-				.throw('Config (unknown): Key "name": Property must be a string.');
+				.throw('Config (unnamed): Key "name": Property must be a string.');
 
 		});
 	});

--- a/tests/config-array.test.js
+++ b/tests/config-array.test.js
@@ -372,7 +372,7 @@ describe('ConfigArray', () => {
 					files: ['*.js', undefined]
 				}
 			],
-			expectedError: 'Config "0": Key "files": Items must be a string, a function, or an array of strings and functions.'
+			expectedError: 'Base Config "0": Key "files": Items must be a string, a function, or an array of strings and functions.'
 		});
 
 		testValidationError({
@@ -382,7 +382,7 @@ describe('ConfigArray', () => {
 					ignores: undefined
 				}
 			],
-			expectedError: 'Config "0": Key "ignores": Expected value to be an array.'
+			expectedError: 'Base Config "0": Key "ignores": Expected value to be an array.'
 		});
 
 		testValidationError({
@@ -393,7 +393,7 @@ describe('ConfigArray', () => {
 					ignores: ['ignored/**', -1]
 				}
 			],
-			expectedError: 'Config "foo": Key "ignores": Expected array to only contain strings and functions.'
+			expectedError: 'Base Config "foo": Key "ignores": Expected array to only contain strings and functions.'
 		});
 
 		testValidationError({
@@ -425,13 +425,31 @@ describe('ConfigArray', () => {
 
 		});
 
-		it('should throw an error when name is not a string', async () => {
+		it('should throw an error when base config name is not a string', async () => {
 			configs = new ConfigArray([
 				{
 					files: ['**'],
 					name: true
 				}
 			], { basePath });
+			await configs.normalize();
+
+			expect(() => {
+				configs.getConfig(path.resolve(basePath, 'foo.js'));
+			})
+				.to
+				.throw('Base Config "0": Key "name": Property must be a string.');
+
+		});
+
+		it('should throw an error when additional config name is not a string', async () => {
+			configs = new ConfigArray([{}], { basePath });
+			configs.push(
+				{
+					files: ['**'],
+					name: true
+				}
+			);
 			await configs.normalize();
 
 			expect(() => {

--- a/tests/config-array.test.js
+++ b/tests/config-array.test.js
@@ -369,10 +369,11 @@ describe('ConfigArray', () => {
 			title: 'should throw an error when files contains an invalid element',
 			configs: [
 				{
+					name: '',
 					files: ['*.js', undefined]
 				}
 			],
-			expectedError: 'Base Config "0": Key "files": Items must be a string, a function, or an array of strings and functions.'
+			expectedError: 'Config (unknown): Key "files": Items must be a string, a function, or an array of strings and functions.'
 		});
 
 		testValidationError({
@@ -382,7 +383,7 @@ describe('ConfigArray', () => {
 					ignores: undefined
 				}
 			],
-			expectedError: 'Base Config "0": Key "ignores": Expected value to be an array.'
+			expectedError: 'Config (unknown): Key "ignores": Expected value to be an array.'
 		});
 
 		testValidationError({
@@ -393,7 +394,7 @@ describe('ConfigArray', () => {
 					ignores: ['ignored/**', -1]
 				}
 			],
-			expectedError: 'Base Config "foo": Key "ignores": Expected array to only contain strings and functions.'
+			expectedError: 'Config "foo": Key "ignores": Expected array to only contain strings and functions.'
 		});
 
 		testValidationError({
@@ -438,7 +439,7 @@ describe('ConfigArray', () => {
 				configs.getConfig(path.resolve(basePath, 'foo.js'));
 			})
 				.to
-				.throw('Base Config "0": Key "name": Property must be a string.');
+				.throw('Config (unknown): Key "name": Property must be a string.');
 
 		});
 
@@ -456,7 +457,7 @@ describe('ConfigArray', () => {
 				configs.getConfig(path.resolve(basePath, 'foo.js'));
 			})
 				.to
-				.throw('Config "0": Key "name": Property must be a string.');
+				.throw('Config (unknown): Key "name": Property must be a string.');
 
 		});
 	});

--- a/tests/config-array.test.js
+++ b/tests/config-array.test.js
@@ -372,7 +372,7 @@ describe('ConfigArray', () => {
 					files: ['*.js', undefined]
 				}
 			],
-			expectedError: 'Key "files": Items must be a string, a function, or an array of strings and functions.'
+			expectedError: 'Config "0": Key "files": Items must be a string, a function, or an array of strings and functions.'
 		});
 
 		testValidationError({
@@ -382,28 +382,30 @@ describe('ConfigArray', () => {
 					ignores: undefined
 				}
 			],
-			expectedError: 'Key "ignores": Expected value to be an array.'
+			expectedError: 'Config "0": Key "ignores": Expected value to be an array.'
 		});
 
 		testValidationError({
 			title: 'should throw an error when a global ignores contains an invalid element',
 			configs: [
 				{
+					name: 'foo',
 					ignores: ['ignored/**', -1]
 				}
 			],
-			expectedError: 'Key "ignores": Expected array to only contain strings and functions.'
+			expectedError: 'Config "foo": Key "ignores": Expected array to only contain strings and functions.'
 		});
 
 		testValidationError({
 			title: 'should throw an error when a non-global ignores contains an invalid element',
 			configs: [
 				{
+					name: 'foo',
 					files: ['*.js'],
 					ignores: [-1]
 				}
 			],
-			expectedError: 'Key "ignores": Expected array to only contain strings and functions.'
+			expectedError: 'Config "foo": Key "ignores": Expected array to only contain strings and functions.'
 		});
 
 		it('should throw an error when a config is not an object', async () => {
@@ -436,7 +438,7 @@ describe('ConfigArray', () => {
 				configs.getConfig(path.resolve(basePath, 'foo.js'));
 			})
 				.to
-				.throw('Key "name": Property must be a string.');
+				.throw('Config "0": Key "name": Property must be a string.');
 
 		});
 	});
@@ -730,6 +732,25 @@ describe('ConfigArray', () => {
 				expect(config.defs.name).to.equal('async-from-context');
 				expect(config.defs.css).to.be.false;
 				expect(config.defs.universal).to.be.true;
+			});
+
+			it('should throw an error when defs doesn\'t pass validation', async () => {
+				const configs = new ConfigArray([
+					{
+						files: ['**/*.js'],
+						defs: 'foo',
+						name: 'bar'
+					}
+				], { basePath, schema });
+
+				await configs.normalize();
+
+				const filename = path.resolve(basePath, 'foo.js');
+				expect(() => {
+					configs.getConfig(filename);
+				})
+					.to
+					.throw('Config "bar": Key "defs": Object expected.');
 			});
 
 			it('should calculate correct config when passed JS filename that matches a function config returning an array', () => {


### PR DESCRIPTION
Updates the thrown errors to include the name of the config object. If the name isn't available, then the index in the array is reported.

Refs https://github.com/eslint/eslint/issues/18231

cc @mdjermanovic @fasttime 