### PR TITLE
fix: ignore `name` field for global `ignores`

### DIFF
--- a/src/config-array.js
+++ b/src/config-array.js
@@ -31,6 +31,11 @@ const MINIMATCH_OPTIONS = {
 
 const CONFIG_TYPES = new Set(['array', 'function']);
 
+/**
+ * Fields that are considered metadata and not part of the config object.
+ */
+const META_FIELDS = new Set(['name']);
+
 const FILES_AND_IGNORES_SCHEMA = new ObjectSchema(filesAndIgnoresSchema);
 
 /**
@@ -597,7 +602,7 @@ export class ConfigArray extends Array {
 			 * In this case, it acts list a globally ignored pattern. If there
 			 * are additional keys, then ignores act like exclusions.
 			 */
-			if (config.ignores && Object.keys(config).length === 1) {
+			if (config.ignores && Object.keys(config).filter(key => !META_FIELDS.has(key)).length === 1) {
 				result.push(...config.ignores);
 			}
 		}

--- a/tests/config-array.test.js
+++ b/tests/config-array.test.js
@@ -2116,6 +2116,22 @@ describe('ConfigArray', () => {
 				expect(ignores).to.deep.equal(expectedIgnores);
 
 			});
+
+			it('should ignore name field for when considering global ignores', () => {
+				configs = new ConfigArray([
+					{
+						name: 'foo',
+						ignores: ['ignoreme']
+					},
+				], {
+					basePath
+				});
+
+				configs.normalizeSync();
+
+				expect(configs.isFileIgnored(path.join(basePath, 'ignoreme/foo.js'))).to.be.true;
+				expect(configs.ignores).to.eql(['ignoreme']);
+			});
 		});
 
 		describe('push()', () => {


### PR DESCRIPTION
Current `ignores` will no longer apply when `name` is specified - which means we can't have `name` field to describe configs for global ignores