### PR TITLE
fix: don't match config with `ignores` and `name` only

### DIFF
--- a/src/config-array.js
+++ b/src/config-array.js
@@ -334,7 +334,7 @@ function pathMatchesIgnores(filePath, basePath, config) {
 	 */
 	const relativeFilePath = path.relative(basePath, filePath);
 
-	return Object.keys(config).length > 1 &&
+	return Object.keys(config).filter(key => !META_FIELDS.has(key)).length > 1 &&
 		!shouldIgnorePath(config.ignores, filePath, relativeFilePath);
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/humanwhocodes/config-array/pull/131.

Filters out `name` when determining whether a config with `ignores` but without `files` matches. The new behavior will be that a config with only `name` and `ignores` does not match any file path, as it's an object for global ignores.

I don't think this makes a functional difference, aside from debug output, because those config objects are essentially empty.