### PR TITLE
fix: Throw friendly message for non-object configs

### DIFF
--- a/src/config-array.js
+++ b/src/config-array.js
@@ -50,13 +50,19 @@ class ConfigError extends Error {
 	 * @param {number} index The index of the config object in the array.
 	 * @param {Error} source The source error. 
 	 */
-	constructor(name, index, source) {
-		super(`Config ${name}: ${source.message}`, { cause: source });
+	constructor(name, index, { cause, message }) {
+
+
+		const finalMessage = message || cause.message;
+
+		super(`Config ${name}: ${finalMessage}`, { cause });
 
 		// copy over custom properties that aren't represented
-		for (const key of Object.keys(source)) {
-			if (!(key in this)) {
-				this[key] = source[key];
+		if (cause) {
+			for (const key of Object.keys(cause)) {
+				if (!(key in this)) {
+					this[key] = cause[key];
+				}
 			}
 		}
 
@@ -82,13 +88,12 @@ class ConfigError extends Error {
  * @returns {string} The name of the config object.
  */ 
 function getConfigName(config) {
-	if (typeof config.name === 'string' && config.name) {
+	if (config && typeof config.name === 'string' && config.name) {
 		return `"${config.name}"`;
 	}
 
 	return '(unnamed)';
 }
-
 
 /**
  * Rethrows a config error with additional information about the config object.
@@ -112,19 +117,28 @@ function isString(value) {
 }
 
 /**
- * Creates a function that asserts that the files and ignores keys 
- * of a config object are valid as per base schema.
+ * Creates a function that asserts that the config is valid
+ * during normalization. This checks that the config is not nullish
+ * and that files and ignores keys  of a config object are valid as per base schema.
  * @param {Object} config The config object to check.
  * @param {number} index The index of the config object in the array.
  * @returns {void}
  * @throws {ConfigError} If the files and ignores keys of a config object are not valid.
  */
-function assertValidFilesAndIgnores(config, index) {
+function assertValidBaseConfig(config, index) {
 
-	if (!config || typeof config !== 'object') {
-		return;
+	if (config === null) {
+		throw new ConfigError(getConfigName(config), index, { message: 'Unexpected null config.' });
 	}
-	
+
+	if (config === undefined) {
+		throw new ConfigError(getConfigName(config), index, { message: 'Unexpected undefined config.' });
+	}
+
+	if (typeof config !== 'object') {
+		throw new ConfigError(getConfigName(config), index, { message: 'Unexpected non-object config.' });
+	}
+
 	const validateConfig = { };
 	
 	if ('files' in config) {
@@ -634,7 +648,7 @@ export class ConfigArray extends Array {
 			const normalizedConfigs = await normalize(this, context, this.extraConfigTypes);
 			this.length = 0;
 			this.push(...normalizedConfigs.map(this[ConfigArraySymbol.preprocessConfig].bind(this)));
-			this.forEach(assertValidFilesAndIgnores);
+			this.forEach(assertValidBaseConfig);
 			this[ConfigArraySymbol.isNormalized] = true;
 
 			// prevent further changes
@@ -656,7 +670,7 @@ export class ConfigArray extends Array {
 			const normalizedConfigs = normalizeSync(this, context, this.extraConfigTypes);
 			this.length = 0;
 			this.push(...normalizedConfigs.map(this[ConfigArraySymbol.preprocessConfig].bind(this)));
-			this.forEach(assertValidFilesAndIgnores);
+			this.forEach(assertValidBaseConfig);
 			this[ConfigArraySymbol.isNormalized] = true;
 
 			// prevent further changes

--- a/tests/config-array.test.js
+++ b/tests/config-array.test.js
@@ -416,13 +416,12 @@ describe('ConfigArray', () => {
 				},
 				'eslint:reccommended' // typo
 			], { basePath });
-			await configs.normalize();
 
 			expect(() => {
-				configs.getConfig(path.resolve(basePath, 'foo.js'));
+				configs.normalizeSync();
 			})
 				.to
-				.throw('All arguments must be objects.');
+				.throw('Config (unnamed): Unexpected non-object config.');
 
 		});
 
@@ -433,6 +432,7 @@ describe('ConfigArray', () => {
 					name: true
 				}
 			], { basePath });
+			
 			await configs.normalize();
 
 			expect(() => {
@@ -451,6 +451,7 @@ describe('ConfigArray', () => {
 					name: true
 				}
 			);
+			
 			await configs.normalize();
 
 			expect(() => {
@@ -458,6 +459,52 @@ describe('ConfigArray', () => {
 			})
 				.to
 				.throw('Config (unnamed): Key "name": Property must be a string.');
+
+		});
+
+		it('should throw an error when base config is undefined', async () => {
+			configs = new ConfigArray([undefined], { basePath });
+			
+			expect(() => {
+				configs.normalizeSync();
+			})
+				.to
+				.throw('Config (unnamed): Unexpected undefined config.');
+
+		});
+
+		it('should throw an error when base config is null', async () => {
+			configs = new ConfigArray([null], { basePath });
+			
+			expect(() => {
+				configs.normalizeSync();
+			})
+				.to
+				.throw('Config (unnamed): Unexpected null config.');
+
+		});
+
+		it('should throw an error when additional config is undefined', async () => {
+			configs = new ConfigArray([{}], { basePath });
+			configs.push(undefined);
+			
+			expect(() => {
+				configs.normalizeSync();
+			})
+				.to
+				.throw('Config (unnamed): Unexpected undefined config.');
+
+		});
+
+		it('should throw an error when additional config is null', async () => {
+			configs = new ConfigArray([{}], { basePath });
+			configs.push(null);
+
+			expect(() => {
+				configs.normalizeSync();
+			})
+				.to
+				.throw('Config (unnamed): Unexpected null config.');
 
 		});
 	});


### PR DESCRIPTION
Adds explicit validation and clear error messages for:

1. `undefined` configs
2. `null` configs
3. non-object configs

All of these checks happen during normalization.

refs https://github.com/eslint/eslint/issues/18259